### PR TITLE
Expose vinyl `relative` property within template

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,10 @@ var PluginError = gutil.PluginError;
 
 var PLUGIN_NAME = 'gulp-wrap';
 
-function compile(contents, template, data, options){
+function compile(contents, template, vinyl, data, options){
   data = data !== undefined ? data : {};
   data.contents = contents;
+  data.relative = vinyl.relative;
   return tpl(template, data, options);
 }
 
@@ -31,7 +32,7 @@ module.exports = function(opts, data, options){
     if (gutil.isStream(file.contents)) {
       var through = es.through();
       var wait = es.wait(function(err, contents){
-        through.write(compile(contents, template, data, options));
+        through.write(compile(contents, template, file, data, options));
         through.end();
       });
       file.contents.pipe(wait);
@@ -39,7 +40,7 @@ module.exports = function(opts, data, options){
     }
 
     if (gutil.isBuffer(file.contents)) {
-      file.contents = new Buffer(compile(file.contents.toString('utf-8'), template, data, options));
+      file.contents = new Buffer(compile(file.contents.toString('utf-8'), template, file, data, options));
     }
 
     callback(null, file);

--- a/test/fixtures/template-vinyl.txt
+++ b/test/fixtures/template-vinyl.txt
@@ -1,0 +1,1 @@
+BEFORE <%= cwd %> AFTER

--- a/test/main.js
+++ b/test/main.js
@@ -144,4 +144,32 @@ describe('gulp-wrap', function () {
     stream.end();
   });
 
+  it('should handle vinyl `relative` attribute', function (done) {
+    var srcFile = new gutil.File({
+      path: 'test/fixtures/hello.txt',
+      cwd: 'test/',
+      base: 'test/fixtures',
+      contents: fs.readFileSync('test/fixtures/hello.txt')
+    });
+
+    var stream = wrap('BEFORE <%= relative %> AFTER');
+
+    stream.on('error', function (err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function (newFile) {
+
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal('BEFORE hello.txt AFTER');
+      done();
+    });
+
+    stream.write(srcFile);
+    stream.end();
+  });
+
 });


### PR DESCRIPTION
To make my templates more flexible, I want access to the filename as well as the file contents in the template locals.
