### PR TITLE
use file.data as optional default data

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var PLUGIN_NAME = 'gulp-wrap';
 
 function compile(file, contents, template, data, options){
   data = data !== undefined ? data : {};
+  if (file.data) {
+    data = extend(true, {}, file.data, data);
+  }
   data.contents = contents;
   /*
    * Add `file` field to source obj used when interpolating


### PR DESCRIPTION
In alignment with gulp-data would be nice if file.data could be used as the data without having to specify file.data.your_variable.
