### PR TITLE
Add ability to generate the template with a callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ The stream contents will be available in the template using the `contents` key. 
 ### wrap(template\[,data\]\[,options\])
 
 #### template
-Type: `String` or `Object`
+Type: `String` or `Object` or `Function`
 
-The template to used. When a `String` then it will be used as the template. When an `Object` then the template will be loaded from file.
+The template to used. When a `String` then it will be used as the template. When an `Object` then the template will be loaded from file. When a `Function` then the function will be called and should return the template content. This function get the `data` object as first parameter.
 
 #### template.src
 Type: `String`

--- a/index.js
+++ b/index.js
@@ -36,6 +36,12 @@ function compile(file, contents, template, data, options){
    * by the file.
    */
   data = extend(true, { file: file }, data);
+  /*
+   * Allow template to be a function, pass it the data object.
+   */
+  if (typeof template === 'function') {
+    template = template(data);
+  }
   return tpl(template, data, options);
 }
 


### PR DESCRIPTION
Hey there,

Thanks for that plugin! I needed to be able to generate template on the fly with a callback function rather than giving a string or file.

Turned out that it's only three lines of code and fully compliant with existing code so I made the addition. Are you ok to pull?

Cheers,
Xav
