### PR TITLE
Adds a try-catch block to wrap consolidate's render method to handle exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,13 +62,17 @@ module.exports = function gulpWrap(opts, data, options) {
           template = template(newData);
         }
 
-        consolidate[options.engine].render(template, newData, function(err, result) {
-          if (err) {
-            done(new PluginError(PLUGIN_NAME, err));
-            return;
-          }
-          done(null, new Buffer(result));
-        });
+        try {
+          consolidate[options.engine].render(template, newData, function(err, result) {
+            if (err) {
+              done(new PluginError(PLUGIN_NAME, err));
+              return;
+            }
+            done(null, new Buffer(result));
+          });
+        } catch (err) {
+          done(new PluginError(PLUGIN_NAME, err));
+        }
       }, done);
     }
 


### PR DESCRIPTION
Some template render methods in the consolidate library were implemented like this:
```js
// https://github.com/tj/consolidate.js/blob/master/lib/consolidate.js
exports.lodash.render = function(str, options, fn) {
  var engine = requires.lodash || (requires.lodash = require('lodash'));
  try {
    var tmpl = cache(options) || cache(options, engine.template(str, null, options));
    fn(null, tmpl(options).replace(/\n$/, ''));
  } catch (err) {
    fn(err);
  }
};
```

The require() method is not wrapped in the try-catch block. If the template engine is not installed, the require() method will throw an error immediately, and there is no chance to catch errors in render's `fn` callback.

I suggest adding a try-catch block to wrap consolidate's render method to handle exceptions, and provide an example of error handling in the documentation as the following:

```js
var gulp = require("gulp");
var gutil = require("gulp-util");
var wrap = require("gulp-wrap");

gulp.src("./src/*.json")
    .pipe(wrap("<%= contents %>"))
        .on("error", gutil.log);
    .pipe(gulp.dest("./dist"));
```