### PR TITLE
Allow functions to be passed to 'data' and 'options'

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,15 +28,23 @@ module.exports = function gulpWrap(opts, data, options) {
     promise = ES6Promise.resolve(opts);
   }
 
-  data = data || {};
-  options = options || {};
-
-  if (!options.engine) {
-    options.engine = 'lodash';
-  }
-
   return through.obj(function gulpWrapTransform(file, enc, cb) {
     function compile(contents, done) {
+      if (typeof data === 'function') {
+        data = data.call(null, file);
+      }
+
+      if (typeof options === 'function') {
+        options = options.call(null, file);
+      }
+
+      data = data || {};
+      options = options || {};
+
+      if (!options.engine) {
+        options.engine = 'lodash';
+      }
+
       // attempt to parse the file contents for JSON or YAML files
       if (options.parse !== false) {
         var ext = path.extname(file.path).toLowerCase();

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,26 @@ describe('gulp-wrap', function() {
     .end(new File({contents: new Buffer('Hello')}));
   });
 
+  it('should allow for dynamic options', function(done) {
+    var srcFile = new File({contents: new Buffer('Hello')});
+    srcFile.dataProp = 'data';
+
+    wrap(
+      'BEFORE <%= data.contents %> <%= data.someVar %> AFTER',
+      {someVar: 'someVal'},
+      function (file) {
+        return {variable: file.dataProp};
+      }
+    )
+    .on('error', done)
+    .on('data', function(file) {
+      assert(file.isBuffer());
+      assert.equal(String(file.contents), 'BEFORE Hello someVal AFTER');
+      done();
+    })
+    .end(srcFile);
+  });
+
   it('should allow file props in the template data', function(done) {
     var srcFile = new File({contents: new Buffer('Hello')});
     srcFile.someProp = 'someValue';
@@ -108,6 +128,24 @@ describe('gulp-wrap', function() {
     .on('data', function(file) {
       assert(file.isBuffer());
       assert.equal(String(file.contents), 'Hello - foo');
+      done();
+    })
+    .end(srcFile);
+  });
+
+  it('should allow for dynamic data', function (done) {
+    var srcFile = new File({contents: new Buffer('Hello')});
+    srcFile.someProp = 'bar';
+
+    wrap('<%= contents %> - <%= file.someProp %>', function (file) {
+      return {
+        file: {someProp: 'foo-' + file.someProp}
+      };
+    })
+    .on('error', done)
+    .on('data', function(file) {
+      assert(file.isBuffer());
+      assert.equal(String(file.contents), 'Hello - foo-bar');
       done();
     })
     .end(srcFile);
@@ -206,5 +244,4 @@ describe('gulp-wrap', function() {
       contents: new Buffer('name: foo')
     }));
   });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ describe('gulp-wrap', function() {
     wrap(
       'BEFORE <%= data.contents %> <%= data.someVar %> AFTER',
       {someVar: 'someVal'},
-      function (file) {
+      function(file) {
         return {variable: file.dataProp};
       }
     )
@@ -133,11 +133,11 @@ describe('gulp-wrap', function() {
     .end(srcFile);
   });
 
-  it('should allow for dynamic data', function (done) {
+  it('should allow for dynamic data', function(done) {
     var srcFile = new File({contents: new Buffer('Hello')});
     srcFile.someProp = 'bar';
 
-    wrap('<%= contents %> - <%= file.someProp %>', function (file) {
+    wrap('<%= contents %> - <%= file.someProp %>', function(file) {
       return {
         file: {someProp: 'foo-' + file.someProp}
       };


### PR DESCRIPTION
I have found that I need to modify the options given to the tempting engine based upon the file and it seems that the only way to do that is by passing in a callback. 