### PR TITLE
make consolidate use local lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var readFile = require('fs-readfile-promise');
 var through = require('through2');
 var tryit = require('tryit');
 var VinylBufferStream = require('vinyl-bufferstream');
+consolidate.requires.lodash = require('lodash');
 
 var PLUGIN_NAME = 'gulp-wrap';
 


### PR DESCRIPTION
The 0.12.0 version updated the consolidate.js version to 0.14 that broke compatibility with lodash < v3 (see https://github.com/tj/consolidate.js/issues/220). 

A problem can arise in a large project at installation using npm3 if another dependency requires a version of lodash < 3. That version may be placed in the top level `node_modules` folder together with consolidate and used instead of the lodash in gulp-wrap placed in `node_modules/gulp-wrap/node_modules/lodash`. 

Avoid this problem by telling cosolidate to use the local lodash.

Fixes: https://github.com/adamayres/gulp-wrap/issues/28