### PR TITLE
Fix `data` and `options` functions for multiple files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ var PLUGIN_NAME = 'gulp-wrap';
 
 module.exports = function gulpWrap(opts, data, options) {
   var promise;
+  var dataFn;
+  var optionsFn;
+
   if (typeof opts === 'object') {
     if (typeof opts.src !== 'string') {
       throw new PluginError(PLUGIN_NAME, new TypeError('Expecting `src` option.'));
@@ -29,14 +32,22 @@ module.exports = function gulpWrap(opts, data, options) {
     promise = ES6Promise.resolve(opts);
   }
 
+  if (typeof data === 'function') {
+    dataFn = data;
+  }
+
+  if (typeof options === 'function') {
+    optionsFn = options;
+  }
+
   return through.obj(function gulpWrapTransform(file, enc, cb) {
     function compile(contents, done) {
-      if (typeof data === 'function') {
-        data = data.call(null, file);
+      if (dataFn) {
+        data = dataFn.call(null, file);
       }
 
-      if (typeof options === 'function') {
-        options = options.call(null, file);
+      if (optionsFn) {
+        options = optionsFn.call(null, file);
       }
 
       data = data || {};

--- a/test/test.js
+++ b/test/test.js
@@ -347,4 +347,62 @@ describe('gulp-wrap', function() {
       contents: Buffer.from('foo')
     }));
   });
+
+  it('should execute the `data` function for each file', function(done) {
+    var wrap = require('..');
+    var n = 0;
+
+    var stream = wrap('<%- stem %>', function(file) {
+      return {stem: file.stem};
+    })
+    .on('error', done)
+    .on('data', function(file) {
+      assert(file.isBuffer());
+      assert.equal(String(file.contents), file.stem);
+      if (++n === 2) {
+        done();
+      }
+    });
+
+    stream.write(new File({
+      path: 'path/to/first',
+      contents: Buffer.from(' ')
+    }));
+
+    stream.write(new File({
+      path: 'path/to/second',
+      contents: Buffer.from(' ')
+    }));
+
+    stream.end();
+  });
+
+  it('should execute the `options` function for each file', function(done) {
+    var wrap = require('..');
+    var n = 0;
+
+    var stream = wrap('<%- stem %>', {}, function(file) {
+      return {stem: file.stem};
+    })
+    .on('error', done)
+    .on('data', function(file) {
+      assert(file.isBuffer());
+      assert.equal(String(file.contents), file.stem);
+      if (++n === 2) {
+        done();
+      }
+    });
+
+    stream.write(new File({
+      path: 'path/to/first',
+      contents: Buffer.from(' ')
+    }));
+
+    stream.write(new File({
+      path: 'path/to/second',
+      contents: Buffer.from(' ')
+    }));
+
+    stream.end();
+  });
 });


### PR DESCRIPTION
Currently, if you pass in a function as the `data` or `options` arguments, it only gets called for the first file in a stream. For subsequent files, the return value of that first call is passed to the template.

This PR fixes this, so that those functions are now called again for each file in the stream.
